### PR TITLE
Add automated workflows to generate indexes

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,20 @@
+# For details and description, see https://github.com/BSData/chatops
+name: ChatOps
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '/')
+    steps:
+      - name: Checkout ChatOps repo
+        uses: actions/checkout@v2
+        with:
+          repository: BSData/chatops
+          path: chatops
+      - name: /command dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.SLASH_COMMAND_DISPATCH_TOKEN }}
+          config-from-file: chatops/commands.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+# This action continuously checks all pushes and Pull requests
+# for validity, integrity and bugs in datafiles.
+# For details, visit https://github.com/BSData/check-datafiles
+name: CI
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: BSData/check-datafiles@v1
+      id: check
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: artifact
+        path: ${{ steps.check.outputs.staging-path }}

--- a/.github/workflows/publish-catpkg.yml
+++ b/.github/workflows/publish-catpkg.yml
@@ -1,0 +1,12 @@
+# This workflow adds the necessary assets to every release
+# For more details, visit https://github.com/BSData/publish-catpkg
+name: Publish catpkg
+on:
+  release:
+    types: [ published, edited ]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: BSData/publish-catpkg@v1


### PR DESCRIPTION
I tried setting up an `index.xml` for the repo so it could be easily loaded via BattleScribe (to alleviate the issues discussed on the Facebook Group). This did not work very well and I was pointed to the BSData workflows that autogenerate the indexes etc based on the `.cat` and `.gst` files. This adds those workflows and then will be run whenever a GitHub release is created. The guide for creating a release for the workflow is here: https://github.com/BSData/catalogue-development/wiki/Data-Author-Guide#releasing

Additional info on self hosting BattleScribe data on GitHub is here: https://github.com/BSData/catalogue-development/wiki/Help:-Hosting-repositories

ToDo: Update the Readme with screenshots of how to load data into BattleScribe using these indexes